### PR TITLE
Fix import error in test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# expo-kokoro
+
+A expo module for using kokoro tts models
+
+# API documentation
+
+- [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/kokoro/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/kokoro/)
+
+# Installation in managed Expo projects
+
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](#api-documentation). If you follow the link and there is no documentation available then this library is not yet usable within managed projects &mdash; it is likely to be included in an upcoming Expo SDK release.
+
+# Installation in bare React Native projects
+
+For bare React Native projects, you must ensure that you have [installed and configured the `expo` package](https://docs.expo.dev/bare/installing-expo-modules/) before continuing.
+
+### Add the package to your npm dependencies
+
+```
+npm install expo-kokoro
+```
+
+### Configure for Android
+
+
+
+
+### Configure for iOS
+
+Run `npx pod-install` after installing the npm package.
+
+# Contributing
+
+Contributions are very welcome! Please refer to guidelines described in the [contributing guide]( https://github.com/expo/expo#contributing).

--- a/package.json
+++ b/package.json
@@ -48,9 +48,14 @@
     "react-native": "*"
   },
   "jest": {
-    "preset": "jest-expo",
+    "preset": "ts-jest",
+    "testEnvironment": "node",
     "testMatch": [
       "**/__tests__/**/*.(test|spec).(ts|tsx|js|jsx)"
-    ]
+    ],
+    "moduleFileExtensions": ["ts", "tsx", "js", "jsx", "json"],
+    "transform": {
+      "^.+\\.(ts|tsx)$": "ts-jest"
+    }
   }
 }

--- a/src/__tests__/tokenizer.test.ts
+++ b/src/__tests__/tokenizer.test.ts
@@ -1,4 +1,4 @@
-import tokenizer, { Tokenizer } from "../tokenizer";
+import { Tokenizer } from "../tokenizer";
 
 describe("Tokenizer", () => {
   it("encodes then decodes back to the same normalized text", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,9 @@
 {
   "extends": "expo-module-scripts/tsconfig.base",
   "compilerOptions": {
-    "outDir": "./build"
+    "outDir": "./build",
+    "resolveJsonModule": true,
+    "esModuleInterop": true
   },
   "include": ["./src"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__rsc_tests__/*"]


### PR DESCRIPTION
Configure Jest for TypeScript and Node environment to resolve import errors during testing.

The `jest-expo` preset was causing a `ReferenceError` by attempting to import files outside the test scope, specifically related to Expo's runtime. Switching to `ts-jest` with a `node` test environment and enabling `resolveJsonModule` and `esModuleInterop` in `tsconfig.json` correctly sets up the testing environment for TypeScript modules.

---
<a href="https://cursor.com/background-agent?bcId=bc-ae2921e3-80e6-4277-a0e3-0f6c3c45a6ef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ae2921e3-80e6-4277-a0e3-0f6c3c45a6ef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

