### PR TITLE
Us - Uk auto phonemizer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-kokoro",
-  "version": "1.1.6",
+  "version": "1.2.0",
   "description": "A expo module for using kokoro tts models",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/kokoro.ts
+++ b/src/kokoro.ts
@@ -5,6 +5,7 @@ import { load_voice_data, KokoroVoice } from "./voices";
 import floatArrayToWAV from "./wav";
 import { DeepPhonemizer } from 'expo-deep-phonemizer';
 import { Asset } from 'expo-asset';
+import { chooseLanguage } from './language_chooser';
 
 const SAMPLE_RATE = 24000;
 const STYLE_DIM = 256;
@@ -45,7 +46,8 @@ export class Kokoro {
   }
 
   async generate(text: string, voice: KokoroVoice, outputPath: string): Promise<void> {
-    const phonemes = await this.phonemizer.phonemize(text, "en_us", true);
+    const language = chooseLanguage(voice);
+    const phonemes = await this.phonemizer.phonemize(text, language, true);
     const tokens = tokenizer.encode(phonemes);
     const n_tokens = Math.min(Math.max(tokens.length - 2, 0), MAX_PHONEME_LENGTH - 1);
     const offset = n_tokens * STYLE_DIM;

--- a/src/kokoro.web.ts
+++ b/src/kokoro.web.ts
@@ -4,6 +4,7 @@ import { tokenizer } from "./tokenizer";
 import { load_voice_data, KokoroVoice } from "./voices";
 import floatArrayToWAV from "./wav";
 import { DeepPhonemizer } from 'expo-deep-phonemizer';
+import { chooseLanguage } from './language_chooser';
 
 const SAMPLE_RATE = 24000;
 const STYLE_DIM = 256;
@@ -39,7 +40,8 @@ export class Kokoro {
   }
 
   async generate(text: string, voice: KokoroVoice, outputPath: string): Promise<void> {
-    const phonemes = await this.phonemizer.phonemize(text, "en_us", true);
+    const language = chooseLanguage(voice);
+    const phonemes = await this.phonemizer.phonemize(text, language, true);
     const tokens = tokenizer.encode(phonemes);
     const n_tokens = Math.min(Math.max(tokens.length - 2, 0), MAX_PHONEME_LENGTH - 1);
     const offset = n_tokens * STYLE_DIM;

--- a/src/language_chooser.ts
+++ b/src/language_chooser.ts
@@ -1,0 +1,11 @@
+import { KokoroVoice } from "./voices";
+
+export type Language = "en_us" | "en_gb" ;
+
+const LANGUAGE_MAP: Record<string, Language> = {
+    "American": "en_us",
+    "British": "en_gb",
+};
+export function chooseLanguage(voice: KokoroVoice): Language {
+    return LANGUAGE_MAP[voice.nationality] ?? "en_us";
+}


### PR DESCRIPTION
American and British accents have slight differences that can be traced to the phonemes, not just actuation. [Wikipedia](https://en.wikipedia.org/wiki/American_and_British_English_pronunciation_differences)

It would be cool to have the ability to automatically use the most appropriate phonemizer according to the voice that is chosen, since the library that is used here also supports this difference.

`af_bella` should use `en_us` while `bf_alice` should use `en_uk`

Maybe you can find a more elegant solution than what I did, as I see you are also the mantainer of DeepPhonemizer
